### PR TITLE
fix(Tooltip): activator element inherits width from wrapper

### DIFF
--- a/src/components/overlays/tooltip/Tooltip.vue
+++ b/src/components/overlays/tooltip/Tooltip.vue
@@ -103,6 +103,8 @@ $arrowSize: 0.625rem;
   @apply relative inline-flex;
 
   .activator {
+    width: inherit;
+
     @apply inline;
   }
 }


### PR DESCRIPTION
Closes #(issue_number)