### PR TITLE
fix: add undefined value to Icon and Button

### DIFF
--- a/src/components/buttons/button/Button.vue
+++ b/src/components/buttons/button/Button.vue
@@ -3,6 +3,7 @@ import { type ContextColorsType } from '@/consts/colors';
 import { default as RuiProgress } from '@/components/progress/Progress.vue';
 
 export interface Props {
+  value?: unknown;
   disabled?: boolean;
   loading?: boolean;
   color?: ContextColorsType;
@@ -19,6 +20,7 @@ defineOptions({
 });
 
 const props = withDefaults(defineProps<Props>(), {
+  value: undefined,
   disabled: false,
   loading: false,
   color: undefined,

--- a/src/components/icons/Icon.vue
+++ b/src/components/icons/Icon.vue
@@ -3,6 +3,7 @@ import { type ContextColorsType } from '@/consts/colors';
 import { type RuiIcons } from '~/src';
 
 export interface Props {
+  value?: unknown;
   name: RuiIcons;
   size?: number | string;
   color?: ContextColorsType;
@@ -13,6 +14,7 @@ defineOptions({
 });
 
 const props = withDefaults(defineProps<Props>(), {
+  value: undefined,
   size: 24,
   color: undefined,
 });


### PR DESCRIPTION
This is to help with VMenu migration since it requires a value.

Closes #(issue_number)