### PR TITLE
fix: error from button group

### DIFF
--- a/src/components/buttons/button-group/ButtonGroup.vue
+++ b/src/components/buttons/button-group/ButtonGroup.vue
@@ -35,7 +35,7 @@ const slots = useSlots();
 const { value, required } = toRefs(props);
 const children = computed(() =>
   (slots.default?.() ?? []).map((node, i) => {
-    const propsData = node.componentOptions?.propsData as ButtonProps;
+    const propsData = (node.componentOptions?.propsData || {}) as ButtonProps;
 
     propsData.active = activeItem(propsData?.value ?? i);
     return { node, props: propsData };


### PR DESCRIPTION
Fix this error:
```
dialog.ts:28 TypeError: Cannot set properties of undefined (setting 'active')
    at index-aa6117f3.js:383:20
    at Array.map (<anonymous>)
    at VueComponent.<anonymous> (index-aa6117f3.js:380:71)
    at Watcher2.get (vue.runtime.esm.js:3446:33)
    at Watcher2.evaluate (vue.runtime.esm.js:3547:27)
    at get value [as value] (vue.runtime.esm.js:1388:29)
    at Object.get [as children] (vue.runtime.esm.js:1201:28)
    at Proxy.dr2 (index-aa6117f3.js:426:15)
    at Vue2._render (vue.runtime.esm.js:2684:28)
    at VueComponent.updateComponent (vue.runtime.esm.js:3875:27)
```