### PR TITLE
fix: on wide tables, make fixed header position properly on horizontal scroll in the table

### DIFF
--- a/src/composables/sticky-header.ts
+++ b/src/composables/sticky-header.ts
@@ -109,6 +109,7 @@ export const useStickyTableHeader = (
 
   onMounted(() => {
     toggleStickyClass();
+    useEventListener(tableScroller, 'scroll', toggleStickyClass);
     useEventListener(document.body, 'scroll', toggleStickyClass);
     useEventListener(window, 'resize', toggleStickyClass);
     watchCellWidth();


### PR DESCRIPTION
quick fix to scroll fixed header on table content scroll