### PR TITLE
refactor: add scroll control, when table is inside vertically scrollable container

### DIFF
--- a/example/src/views/DataTableView.vue
+++ b/example/src/views/DataTableView.vue
@@ -622,6 +622,10 @@ const apiDatatables = ref<{ title: string; table: DataTableProps }[]>([
   },
 ]);
 
+const containerScroll = ref(null);
+
+const containedTable = { ...get(emptyTables)[4].table };
+
 const users = computed<Record<string, any>[]>(() =>
   JSON.parse(get(_users) ?? '[]').map(normalize),
 );
@@ -1002,6 +1006,35 @@ function toggleRow(row: any, expanded: any[] | undefined) {
             </template>
             <template #group.header.content="{ groupValue }">
               custom group content: {{ groupValue }}
+            </template>
+          </RuiDataTable>
+        </div>
+        <div
+          ref="containerScroll"
+          class="max-h-[300px] overflow-y-auto mt-10"
+        >
+          <RuiDataTable
+            v-bind="objectOmit(containedTable, ['value', 'pagination', 'sort', 'stickyHeader'])"
+            v-model="containedTable.value"
+            :pagination.sync="containedTable.pagination"
+            :sort.sync="containedTable.sort"
+            data-cy="table-scroll-parent"
+            :group.sync="containedTable.group"
+            :collapsed.sync="containedTable.collapsed"
+            :scroller="containerScroll"
+            :scroller-offset="0"
+          >
+            <template #item.action>
+              <RuiButton
+                icon
+                variant="text"
+                size="sm"
+              >
+                <RuiIcon
+                  name="more-fill"
+                  color="primary"
+                />
+              </RuiButton>
             </template>
           </RuiDataTable>
         </div>

--- a/src/components/tables/DataTable.vue
+++ b/src/components/tables/DataTable.vue
@@ -150,6 +150,7 @@ export interface Props {
   groupExpandButtonPosition?: 'start' | 'end';
   collapsed?: TableRow[];
   disabledRows?: TableRow[];
+  scroller?: HTMLElement;
 }
 
 defineOptions({
@@ -182,6 +183,7 @@ const props = withDefaults(defineProps<Props>(), {
   group: undefined,
   groupExpandButtonPosition: 'start',
   collapsed: undefined,
+  scroller: undefined,
   disabledRows: undefined,
 });
 
@@ -216,6 +218,7 @@ const {
   groupExpandButtonPosition,
   collapsed,
   disabledRows,
+  scroller,
 } = toRefs(props);
 const tableDefaults = useTable();
 
@@ -866,8 +869,9 @@ function onCheckboxClick(event: any, value: string, index: number) {
 
 function scrollToTop() {
   const { top } = useElementBounding(table);
+  const { top: scrollerTop } = useElementBounding(scroller);
 
-  const wrapper = document.body;
+  const wrapper = get(scroller) ?? document.body;
   const tableEl = get(table);
 
   if (!(tableEl && wrapper))
@@ -875,7 +879,13 @@ function scrollToTop() {
 
   const tableTop = get(top);
   setTimeout(() => {
-    const newScrollTop = tableTop + wrapper.scrollTop - (get(stickyHeaderOffset) ?? 0);
+    let newScrollTop = tableTop + wrapper.scrollTop - 2;
+
+    if (get(scroller)) {
+      newScrollTop -= get(scrollerTop) - tableEl.scrollTop;
+      wrapper.style.scrollBehavior = 'smooth';
+    }
+    else { newScrollTop -= (get(stickyHeaderOffset) ?? 0); }
 
     if (wrapper.scrollTop > newScrollTop)
       wrapper.scrollTop = newScrollTop;


### PR DESCRIPTION
(other than body)

Paginating a table inside a modal when there's a scroll should no longer scroll body, should scroll to top inside the modal.
